### PR TITLE
[FEAT] Regreso a clap sin perder legibilidad de structopt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,106 +3,125 @@
 version = 4
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
+name = "anstream"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
- "winapi",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
+name = "anstyle"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
+ "utf8parse",
 ]
 
 [[package]]
-name = "bitflags"
-version = "1.3.2"
+name = "anstyle-query"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys",
+]
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "clap_builder",
+ "clap_derive",
 ]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
+name = "is_terminal_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "libc"
-version = "0.2.169"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "next"
 version = "0.1.0"
 dependencies = [
- "structopt",
+ "clap",
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
+name = "once_cell"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "proc-macro2"
@@ -124,52 +143,19 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -179,47 +165,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
+name = "utf8parse"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.14"
+name = "windows-sys"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
+ "windows-targets",
 ]
 
 [[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
+name = "windows-targets"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
 
 [[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-structopt = "0.3"
+clap = { version = "4.5.27", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,32 +1,60 @@
 mod interface;
 
-use structopt::StructOpt;
+use clap::{Parser, Subcommand};
 use interface::commands;
 
-#[derive(StructOpt)]
-#[structopt(name = "next", about = "Una aplicación de ejemplo con comandos")]
-enum Next {
-    #[structopt(name = "create", about = "Crea un nuevo proyecto")]
+#[derive(Parser, Debug)]
+#[command(
+    name = "next",
+    about = "Manage your Next app development",
+    version = "1.0",
+    author = "Next Development team <mail@placeholder.com>",
+    subcommand_required = true,
+    arg_required_else_help = true
+)]
+struct Cli{
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+enum Commands {
     Create {
-        #[structopt(help = "El directorio donde se creará el proyecto")]
-        path: String,
+        output_directory: String,
     },
 
-    #[structopt(name = "version", about = "Muestra la versión de la aplicación")]
-    Version,
+    Run{
+        options: Option<String>,
+    },
 
-    #[structopt(name = "info", about = "Muestra información sobre la aplicación")]
+    Add,
+
+    Build,
+
+    CheckEnv,
+
+    Clean,
+
+    Exce,
+
+    Get,
+
     Info,
+
+    Set,
+
+    Use,
+
+    Version,
 }
 
 fn main() {
-    match Next::from_args() {
-        Next::Create { path } => commands::create::create(path),
-        Next::Version => {
-            println!("next versión 1.0");
-        },
-        Next::Info => {
-            println!("next es una aplicación de ejemplo.");
-        },
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Create { output_directory } => commands::create::create(output_directory),
+        //TODO: Add the rest of the commands
+        _ => println!("Not implemented")
     }
+
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use interface::commands;
     name = "next",
     about = "Manage your Next app development",
     version = "1.0",
+    //TODO: Add mail account for the project
     author = "Next Development team <mail@placeholder.com>",
     subcommand_required = true,
     arg_required_else_help = true
@@ -19,11 +20,25 @@ struct Cli{
 
 #[derive(Subcommand, Debug)]
 enum Commands {
+    #[command(
+        name = "create",
+        about = "Create a new project of Next",
+    )]
     Create {
+        #[arg(
+            help = "The directory where the project will be created"
+        )]
         output_directory: String,
     },
 
+    #[command(
+        name = "run",
+        about = "Run your Next application"
+    )]
     Run{
+        #[arg(
+            help = "Options for running the application"
+        )]
         options: Option<String>,
     },
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,24 +42,65 @@ enum Commands {
         options: Option<String>,
     },
 
+    #[command(
+        name = "add",
+        about = "Add to property of current Next project"
+    )]
     Add,
 
+    #[command(
+        name = "build",
+        about = "Build a project of Next"
+    )]
     Build,
 
+    #[command(
+        name = "check_env",
+        about = "Check env for the NextPackages"
+    )]
     CheckEnv,
 
+    #[command(
+        name = "clean",
+        about = "Clean a project of Next"
+    )]
     Clean,
 
+    #[command(
+        name = "exce",
+        //Is this description correct? I copied from the README but idk lol
+        about = "Add to property of Next project"
+    )]
     Exce,
 
+    #[command(
+        name = "get",
+        about = "Get property of the current Next project"
+    )]
     Get,
 
+    #[command(
+        name = "info",
+        about = "View info of current Next project"
+    )]
     Info,
 
+    #[command(
+        name = "set",
+        about = "Set property for the current Next project"
+    )]
     Set,
 
+    #[command(
+        name = "use",
+        about = "Add new library in current project"
+    )]
     Use,
 
+    #[command(
+        name = "version",
+        about = "View version of Next"
+    )]
     Version,
 }
 


### PR DESCRIPTION
## Descripción del cambio
Este PR cambia la librería utilizada de vuelta a clap, pero implementando atributos derivados de esta misma librería para no perder la legibilidad que se había obtenido con structopt

## Motivación
### Mantenibilidad:
El problema de usar structopt es que es una biblioteca que actualmente ha entrado en modo mantenimiento, es decir, no se le agregarán nuevas features y solamente se solucionarán bugs ya existentes. Esto significa que en el futuro puede que sea descontinuada. Por eso, es conveniente migrar a clap >3.0 para tener la posibilidad de que nuestro código pueda seguir sirviéndose de posibles nuevas features en el futuro, y de posibles actualizaciones de seguridad que pueda recibir clap durante la duración de su vida util.

![Screenshot_20250126_143144](https://github.com/user-attachments/assets/36f1b459-d815-425c-aa1e-aa2d8dbb89c7)

### No perder la legibilidad obtenida con structopt
Utilizando macros del atributo derivado clap::Parser podemos lograr conservar la mejora de legibilidad obtenida con structopt y migrar a clap sin problemas.
Con structopt:
```
#[derive(StructOpt)]
#[structopt(name = "next", about = "Una aplicación de ejemplo con comandos")]
enum Next {
    #[structopt(name = "create", about = "Crea un nuevo proyecto")]
    Create {
        #[structopt(help = "El directorio donde se creará el proyecto")]
        path: String,
    },

    #[structopt(name = "version", about = "Muestra la versión de la aplicación")]
    Version,
```

Con clap y su feature derivada Parser:
```
#[derive(Parser, Debug)]
#[command(
    name = "next",
    about = "Manage your Next app development",
    version = "1.0",
    //TODO: Add mail account for the project
    author = "Next Development team <mail@placeholder.com>",
    subcommand_required = true,
    arg_required_else_help = true
)]
struct Cli{
    #[command(subcommand)]
    command: Commands,
}

#[derive(Subcommand, Debug)]
enum Commands {
    #[command(
        name = "create",
        about = "Create a new project of Next",
    )]
    Create {
        #[arg(
            help = "The directory where the project will be created"
        )]
        output_directory: String,
    },
```
## Beneficios del cambio
Legibilidad: No se pierde legibilidad, pues la feature derivada clap::Parser funciona de manera muy parecida a structopt
Mantenibilidad: 

## Pruebas
Se verificó que todos los comandos y argumentos funcionan correctamente después de la migración:

next create .
next version
next info
## Dependencias
Se agregó clap como dependencia en Cargo.toml. Se removió structopt

## Conclusión
La migración a clap nos permite servirnos de una biblioteca que tendrá mayor tiempo de vida útil en el futuro.
Gracias a ahora usar clap::Parser, la legibilidad y ventajas ganadas con structopt se mantienen.